### PR TITLE
Changed 'orchestratorProfile' to accomodate Linux and Windows bootstrap nodes

### DIFF
--- a/cmd/dcos-upgrade.go
+++ b/cmd/dcos-upgrade.go
@@ -184,10 +184,7 @@ func (uc *dcosUpgradeCmd) loadCluster(cmd *cobra.Command) error {
 		return fmt.Errorf("upgrade to DCOS %s is not supported", uc.upgradeVersion)
 	}
 
-	if uc.containerService.Properties.OrchestratorProfile.DcosConfig == nil {
-		uc.containerService.Properties.OrchestratorProfile.DcosConfig = &api.DcosConfig{}
-	}
-	uc.containerService.Properties.OrchestratorProfile.DcosConfig.DcosBootstrapURL = uc.lnxBootstrapURL
+	uc.containerService.Properties.OrchestratorProfile.LinuxBootstrapProfile.BootstrapURL = uc.lnxBootstrapURL
 
 	// Read name suffix to identify nodes in the resource group that belong
 	// to this cluster.

--- a/cmd/dcos-upgrade_test.go
+++ b/cmd/dcos-upgrade_test.go
@@ -20,6 +20,7 @@ var _ = Describe("the upgrade command", func() {
 		Expect(output.Long).Should(Equal(dcosUpgradeLongDescription))
 		Expect(output.Flags().Lookup("location")).NotTo(BeNil())
 		Expect(output.Flags().Lookup("resource-group")).NotTo(BeNil())
+		Expect(output.Flags().Lookup("subscription-id")).NotTo(BeNil())
 		Expect(output.Flags().Lookup("deployment-dir")).NotTo(BeNil())
 		Expect(output.Flags().Lookup("ssh-private-key-path")).NotTo(BeNil())
 		Expect(output.Flags().Lookup("upgrade-version")).NotTo(BeNil())
@@ -38,7 +39,7 @@ var _ = Describe("the upgrade command", func() {
 				uc: &dcosUpgradeCmd{
 					resourceGroupName:   "",
 					deploymentDirectory: "_output/test",
-					upgradeVersion:      "1.8.9",
+					upgradeVersion:      "1.11.0",
 					location:            "centralus",
 					sshPrivateKeyPath:   privKey.Name(),
 					authArgs: authArgs{
@@ -51,7 +52,7 @@ var _ = Describe("the upgrade command", func() {
 				uc: &dcosUpgradeCmd{
 					resourceGroupName:   "test",
 					deploymentDirectory: "_output/test",
-					upgradeVersion:      "1.8.9",
+					upgradeVersion:      "1.11.0",
 					location:            "",
 					sshPrivateKeyPath:   privKey.Name(),
 					authArgs: authArgs{
@@ -77,20 +78,7 @@ var _ = Describe("the upgrade command", func() {
 				uc: &dcosUpgradeCmd{
 					resourceGroupName:   "test",
 					deploymentDirectory: "",
-					upgradeVersion:      "1.9.0",
-					location:            "southcentralus",
-					sshPrivateKeyPath:   privKey.Name(),
-					authArgs: authArgs{
-						rawSubscriptionID: "99999999-0000-0000-0000-000000000000",
-					},
-				},
-				expectedErr: fmt.Errorf("--deployment-dir must be specified"),
-			},
-			{
-				uc: &dcosUpgradeCmd{
-					resourceGroupName:   "test",
-					deploymentDirectory: "",
-					upgradeVersion:      "1.9.0",
+					upgradeVersion:      "1.11.0",
 					location:            "southcentralus",
 					sshPrivateKeyPath:   privKey.Name(),
 					authArgs: authArgs{
@@ -103,7 +91,7 @@ var _ = Describe("the upgrade command", func() {
 				uc: &dcosUpgradeCmd{
 					resourceGroupName:   "test",
 					deploymentDirectory: "_output/mydir",
-					upgradeVersion:      "1.9.0",
+					upgradeVersion:      "1.11.0",
 					location:            "southcentralus",
 					sshPrivateKeyPath:   privKey.Name(),
 					authArgs:            authArgs{},
@@ -114,7 +102,7 @@ var _ = Describe("the upgrade command", func() {
 				uc: &dcosUpgradeCmd{
 					resourceGroupName:   "test",
 					deploymentDirectory: "_output/mydir",
-					upgradeVersion:      "1.9.0",
+					upgradeVersion:      "1.11.0",
 					location:            "southcentralus",
 					authArgs:            authArgs{},
 				},
@@ -124,7 +112,7 @@ var _ = Describe("the upgrade command", func() {
 				uc: &dcosUpgradeCmd{
 					resourceGroupName:   "test",
 					deploymentDirectory: "_output/mydir",
-					upgradeVersion:      "1.9.0",
+					upgradeVersion:      "1.11.0",
 					location:            "southcentralus",
 					sshPrivateKeyPath:   privKey.Name(),
 					authArgs: authArgs{

--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -15,7 +15,10 @@ import (
 const ExampleAPIModel = `{
   "apiVersion": "vlabs",
   "properties": {
-		"orchestratorProfile": { "orchestratorType": "DCOS", "dcosConfig" : { "dcosBootstrapURL": "%s" } },
+    "orchestratorProfile": {
+      "orchestratorType": "DCOS",
+	  "linuxBootstrapProfile" : { "bootstrapURL": "%s" }
+    },
     "masterProfile": { "count": 1, "dnsPrefix": "", "vmSize": "Standard_D2_v2" },
     "agentPoolProfiles": [ { "name": "linuxpool1", "count": 2, "vmSize": "Standard_D2_v2", "availabilityProfile": "AvailabilitySet" } ],
     "windowsProfile": { "adminUsername": "azureuser", "adminPassword": "replacepassword1234$" },
@@ -26,13 +29,16 @@ const ExampleAPIModel = `{
 `
 
 const ExampleAPIModelWithDNSPrefix = `{
-	"apiVersion": "vlabs",
-	"properties": {
-		  "orchestratorProfile": { "orchestratorType": "DCOS", "dcosConfig" : { "dcosBootstrapURL": "%s" } },
-	  "masterProfile": { "count": 1, "dnsPrefix": "mytestcluster", "vmSize": "Standard_D2_v2" },
-	  "agentPoolProfiles": [ { "name": "linuxpool1", "count": 2, "vmSize": "Standard_D2_v2", "availabilityProfile": "AvailabilitySet" } ],
-	  "windowsProfile": { "adminUsername": "azureuser", "adminPassword": "replacepassword1234$" },
-	  "linuxProfile": { "adminUsername": "azureuser", "ssh": { "publicKeys": [ { "keyData": "" } ] }
+  "apiVersion": "vlabs",
+  "properties": {
+    "orchestratorProfile": {
+		"orchestratorType": "DCOS",
+		"linuxBootstrapProfile" : { "bootstrapURL": "%s" }
+	  },
+    "masterProfile": { "count": 1, "dnsPrefix": "mytestcluster", "vmSize": "Standard_D2_v2" },
+    "agentPoolProfiles": [ { "name": "linuxpool1", "count": 2, "vmSize": "Standard_D2_v2", "availabilityProfile": "AvailabilitySet" } ],
+    "windowsProfile": { "adminUsername": "azureuser", "adminPassword": "replacepassword1234$" },
+    "linuxProfile": { "adminUsername": "azureuser", "ssh": { "publicKeys": [ { "keyData": "" } ] }
 	  }
 	}
   }

--- a/examples/dcos-private-registry/README.md
+++ b/examples/dcos-private-registry/README.md
@@ -1,17 +1,15 @@
 # Private Registry Support
 
-ACS can deploy credentials to private registries to agent nodes DC/OS clusters.
+dcos-engine can deploy credentials to private registries to agent nodes DC/OS clusters.
 
 The credentials are specified in the orchestrator profile in the apimodel:
 ```
   "properties": {
     "orchestratorProfile": {
       "orchestratorType": "DCOS",
-      "dcosConfig" : {
-        "Registry" : "",
-        "RegistryUser" : "",
-        "RegistryPassword" : ""
-      }
+      "registry" : "",
+      "registryUser" : "",
+      "registryPassword" : ""
     },
 ```
 
@@ -38,9 +36,9 @@ Let's provision a DC/OS cluster with credentials to an [Azure Container Registry
     },
 ```
 
-- Run acs-engine to create ARM templates
+- Run dcos-engine to create ARM templates
 ```
-./acs-engine generate examples/dcos-private-registry/dcos.json
+./dcos-engine generate examples/dcos-private-registry/dcos.json
 ```
 
 - Deploy the cluster

--- a/examples/dcos-private-registry/dcos.json
+++ b/examples/dcos-private-registry/dcos.json
@@ -3,11 +3,9 @@
   "properties": {
     "orchestratorProfile": {
       "orchestratorType": "DCOS",
-      "dcosConfig" : {
-        "registry" : "",
-        "registryUser" : "",
-        "registryPassword" : ""
-      }
+      "registry" : "",
+      "registryUser" : "",
+      "registryPassword" : ""
     },
     "masterProfile": {
       "count": 1,

--- a/parts/dcos/bootstrapresources.t
+++ b/parts/dcos/bootstrapresources.t
@@ -149,7 +149,7 @@
               "uri": "[concat(reference(concat('Microsoft.Storage/storageAccounts/',variables('masterStorageAccountName')),variables('apiVersionStorage')).primaryEndpoints.blob,'vhds/',variables('bootstrapVMName'),'-osdisk.vhd')]"
             }
 {{end}}
-{{if ne .OrchestratorProfile.DcosConfig.BootstrapProfile.OSDiskSizeGB 0}}
+{{if ne .OrchestratorProfile.LinuxBootstrapProfile.OSDiskSizeGB 0}}
             ,"diskSizeGB": "60"
 {{end}}
           }

--- a/parts/dcos/bootstrapvars.t
+++ b/parts/dcos/bootstrapvars.t
@@ -1,4 +1,4 @@
-{{if .OrchestratorProfile.DcosConfig.BootstrapProfile}}
+{{if .OrchestratorProfile.LinuxBootstrapProfile}}
     ,
     "dcosBootstrapURL": "[parameters('dcosBootstrapURL')]",
     "bootstrapVMSize": "[parameters('bootstrapVMSize')]",

--- a/pkg/acsengine/defaults.go
+++ b/pkg/acsengine/defaults.go
@@ -156,17 +156,17 @@ func setOrchestratorDefaults(cs *api.ContainerService) {
 
 	switch o.OrchestratorType {
 	case api.DCOS:
-		if o.DcosConfig == nil {
-			o.DcosConfig = &api.DcosConfig{}
-		}
 		dcosSemVer, _ := semver.Make(o.OrchestratorVersion)
 		dcosBootstrapSemVer, _ := semver.Make(common.DCOSVersion1Dot11Dot0)
 		if !dcosSemVer.LT(dcosBootstrapSemVer) {
-			if o.DcosConfig.BootstrapProfile == nil {
-				o.DcosConfig.BootstrapProfile = &api.BootstrapProfile{}
+			if o.LinuxBootstrapProfile == nil {
+				o.LinuxBootstrapProfile = &api.BootstrapProfile{}
 			}
-			if len(o.DcosConfig.BootstrapProfile.VMSize) == 0 {
-				o.DcosConfig.BootstrapProfile.VMSize = "Standard_D2s_v3"
+			if len(o.LinuxBootstrapProfile.VMSize) == 0 {
+				o.LinuxBootstrapProfile.VMSize = "Standard_D2s_v3"
+			}
+			if o.WindowsBootstrapProfile == nil {
+				o.WindowsBootstrapProfile = &api.BootstrapProfile{}
 			}
 		}
 	}
@@ -201,9 +201,9 @@ func setMasterNetworkDefaults(a *api.Properties, isUpgrade bool) {
 			if !isUpgrade || len(a.MasterProfile.FirstConsecutiveStaticIP) == 0 {
 				a.MasterProfile.FirstConsecutiveStaticIP = DefaultDCOSFirstConsecutiveStaticIP
 			}
-			if a.OrchestratorProfile.DcosConfig != nil && a.OrchestratorProfile.DcosConfig.BootstrapProfile != nil {
-				if !isUpgrade || len(a.OrchestratorProfile.DcosConfig.BootstrapProfile.StaticIP) == 0 {
-					a.OrchestratorProfile.DcosConfig.BootstrapProfile.StaticIP = DefaultDCOSBootstrapStaticIP
+			if a.OrchestratorProfile.LinuxBootstrapProfile != nil {
+				if !isUpgrade || len(a.OrchestratorProfile.LinuxBootstrapProfile.StaticIP) == 0 {
+					a.OrchestratorProfile.LinuxBootstrapProfile.StaticIP = DefaultDCOSBootstrapStaticIP
 				}
 			}
 		}

--- a/pkg/acsengine/engine.go
+++ b/pkg/acsengine/engine.go
@@ -627,8 +627,8 @@ func GetDCOSBootstrapConfig(cs *api.ContainerService) string {
 
 	config := string(bp)
 	config = strings.Replace(config, "MASTER_IP_LIST", strings.Join(masterIPList, "\n"), -1)
-	config = strings.Replace(config, "BOOTSTRAP_IP", cs.Properties.OrchestratorProfile.DcosConfig.BootstrapProfile.StaticIP, -1)
-	config = strings.Replace(config, "BOOTSTRAP_OAUTH_ENABLED", strconv.FormatBool(cs.Properties.OrchestratorProfile.DcosConfig.BootstrapProfile.OAuthEnabled), -1)
+	config = strings.Replace(config, "BOOTSTRAP_IP", cs.Properties.OrchestratorProfile.LinuxBootstrapProfile.StaticIP, -1)
+	config = strings.Replace(config, "BOOTSTRAP_OAUTH_ENABLED", strconv.FormatBool(cs.Properties.OrchestratorProfile.OAuthEnabled), -1)
 
 	return config
 }
@@ -685,7 +685,7 @@ func getDCOSAgentProvisionScript(profile *api.AgentPoolProfile, orchProfile *api
 	b.WriteString(provisionScript)
 	b.WriteString("\n")
 
-	if len(orchProfile.DcosConfig.Registry) == 0 {
+	if len(orchProfile.Registry) == 0 {
 		b.WriteString("rm /etc/docker.tar.gz\n")
 	}
 

--- a/pkg/acsengine/params.go
+++ b/pkg/acsengine/params.go
@@ -70,25 +70,25 @@ func getParameters(cs *api.ContainerService, isClassicMode bool, generatorCode s
 		dcosBootstrapURL := GetDCOSDefaultBootstrapInstallerURL(properties.OrchestratorProfile.OrchestratorVersion)
 		dcosWindowsBootstrapURL := getDCOSDefaultWindowsBootstrapInstallerURL(properties.OrchestratorProfile)
 
-		if properties.OrchestratorProfile.DcosConfig != nil {
-			if properties.OrchestratorProfile.DcosConfig.DcosWindowsBootstrapURL != "" {
-				dcosWindowsBootstrapURL = properties.OrchestratorProfile.DcosConfig.DcosWindowsBootstrapURL
-			}
-			if properties.OrchestratorProfile.DcosConfig.DcosBootstrapURL != "" {
-				dcosBootstrapURL = properties.OrchestratorProfile.DcosConfig.DcosBootstrapURL
-			}
-			if len(properties.OrchestratorProfile.DcosConfig.Registry) > 0 {
-				addValue(parametersMap, "registry", properties.OrchestratorProfile.DcosConfig.Registry)
-				addValue(parametersMap, "registryKey", base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", properties.OrchestratorProfile.DcosConfig.RegistryUser, properties.OrchestratorProfile.DcosConfig.RegistryPass))))
-			}
+		if len(properties.OrchestratorProfile.Registry) > 0 {
+			addValue(parametersMap, "registry", properties.OrchestratorProfile.Registry)
+			addValue(parametersMap, "registryKey", base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", properties.OrchestratorProfile.RegistryUser, properties.OrchestratorProfile.RegistryPass))))
 		}
 
 		addValue(parametersMap, "dcosBootstrapURL", dcosBootstrapURL)
 		addValue(parametersMap, "dcosWindowsBootstrapURL", dcosWindowsBootstrapURL)
 
-		if properties.OrchestratorProfile.DcosConfig.BootstrapProfile != nil {
-			addValue(parametersMap, "bootstrapStaticIP", properties.OrchestratorProfile.DcosConfig.BootstrapProfile.StaticIP)
-			addValue(parametersMap, "bootstrapVMSize", properties.OrchestratorProfile.DcosConfig.BootstrapProfile.VMSize)
+		if properties.OrchestratorProfile.LinuxBootstrapProfile != nil {
+			if len(properties.OrchestratorProfile.LinuxBootstrapProfile.BootstrapURL) > 0 {
+				dcosBootstrapURL = properties.OrchestratorProfile.LinuxBootstrapProfile.BootstrapURL
+			}
+			addValue(parametersMap, "bootstrapStaticIP", properties.OrchestratorProfile.LinuxBootstrapProfile.StaticIP)
+			addValue(parametersMap, "bootstrapVMSize", properties.OrchestratorProfile.LinuxBootstrapProfile.VMSize)
+		}
+		if properties.OrchestratorProfile.WindowsBootstrapProfile != nil {
+			if len(properties.OrchestratorProfile.WindowsBootstrapProfile.BootstrapURL) > 0 {
+				dcosWindowsBootstrapURL = properties.OrchestratorProfile.WindowsBootstrapProfile.BootstrapURL
+			}
 		}
 	}
 

--- a/pkg/acsengine/template_generator.go
+++ b/pkg/acsengine/template_generator.go
@@ -138,10 +138,7 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 			return false
 		},
 		"HasPrivateRegistry": func() bool {
-			if cs.Properties.OrchestratorProfile.DcosConfig != nil {
-				return len(cs.Properties.OrchestratorProfile.DcosConfig.Registry) > 0
-			}
-			return false
+			return len(cs.Properties.OrchestratorProfile.Registry) > 0
 		},
 		"RequiresFakeAgentOutput": func() bool {
 			return false
@@ -207,8 +204,8 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 				masterPreprovisionExtension += makeMasterExtensionScriptCommands(cs)
 			}
 			var bootstrapIP string
-			if cs.Properties.OrchestratorProfile.DcosConfig != nil && cs.Properties.OrchestratorProfile.DcosConfig.BootstrapProfile != nil {
-				bootstrapIP = cs.Properties.OrchestratorProfile.DcosConfig.BootstrapProfile.StaticIP
+			if cs.Properties.OrchestratorProfile.LinuxBootstrapProfile != nil {
+				bootstrapIP = cs.Properties.OrchestratorProfile.LinuxBootstrapProfile.StaticIP
 			}
 
 			str := getSingleLineDCOSCustomData(
@@ -237,8 +234,8 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 			} else {
 				agentRoleName = "slave"
 			}
-			if cs.Properties.OrchestratorProfile.DcosConfig != nil && cs.Properties.OrchestratorProfile.DcosConfig.BootstrapProfile != nil {
-				bootstrapIP = cs.Properties.OrchestratorProfile.DcosConfig.BootstrapProfile.StaticIP
+			if cs.Properties.OrchestratorProfile.LinuxBootstrapProfile != nil {
+				bootstrapIP = cs.Properties.OrchestratorProfile.LinuxBootstrapProfile.StaticIP
 			}
 
 			str := getSingleLineDCOSCustomData(

--- a/pkg/acsengine/testdata/vnet/dcosvnet.json
+++ b/pkg/acsengine/testdata/vnet/dcosvnet.json
@@ -3,10 +3,8 @@
   "properties": {
     "orchestratorProfile": {
       "orchestratorType": "DCOS",
-      "dcosConfig": {
-        "bootstrapProfile": {
-          "staticIP": "10.100.0.240"
-        }
+      "linuxBootstrapProfile": {
+        "staticIP": "10.100.0.240"
       }
     },
     "masterProfile": {

--- a/pkg/api/converterfromapi.go
+++ b/pkg/api/converterfromapi.go
@@ -169,38 +169,30 @@ func convertOrchestratorProfileToVLabs(api *OrchestratorProfile, o *vlabs.Orches
 		sv, _ := semver.Make(o.OrchestratorVersion)
 		o.OrchestratorRelease = fmt.Sprintf("%d.%d", sv.Major, sv.Minor)
 	}
-
-	if api.DcosConfig != nil {
-		o.DcosConfig = &vlabs.DcosConfig{}
-		convertDcosConfigToVLabs(api.DcosConfig, o.DcosConfig)
-	}
-}
-
-func convertDcosConfigToVLabs(api *DcosConfig, vl *vlabs.DcosConfig) {
-	vl.DcosBootstrapURL = api.DcosBootstrapURL
-	vl.DcosWindowsBootstrapURL = api.DcosWindowsBootstrapURL
-
-	if api.Registry != "" {
-		vl.Registry = api.Registry
-	}
-
-	if api.RegistryUser != "" {
-		vl.RegistryUser = api.RegistryUser
-	}
-
-	if api.RegistryPass != "" {
-		vl.RegistryPass = api.RegistryPass
-	}
-
-	if api.BootstrapProfile != nil {
-		vl.BootstrapProfile = &vlabs.BootstrapProfile{
-			VMSize:       api.BootstrapProfile.VMSize,
-			OSDiskSizeGB: api.BootstrapProfile.OSDiskSizeGB,
-			OAuthEnabled: api.BootstrapProfile.OAuthEnabled,
-			StaticIP:     api.BootstrapProfile.StaticIP,
-			Subnet:       api.BootstrapProfile.Subnet,
+	o.OAuthEnabled = api.OAuthEnabled
+	if api.LinuxBootstrapProfile != nil {
+		o.LinuxBootstrapProfile = &vlabs.BootstrapProfile{
+			BootstrapURL: api.LinuxBootstrapProfile.BootstrapURL,
+			External:     api.LinuxBootstrapProfile.External,
+			VMSize:       api.LinuxBootstrapProfile.VMSize,
+			OSDiskSizeGB: api.LinuxBootstrapProfile.OSDiskSizeGB,
+			StaticIP:     api.LinuxBootstrapProfile.StaticIP,
+			Subnet:       api.LinuxBootstrapProfile.Subnet,
 		}
 	}
+	if api.WindowsBootstrapProfile != nil {
+		o.WindowsBootstrapProfile = &vlabs.BootstrapProfile{
+			BootstrapURL: api.WindowsBootstrapProfile.BootstrapURL,
+			External:     api.WindowsBootstrapProfile.External,
+			VMSize:       api.WindowsBootstrapProfile.VMSize,
+			OSDiskSizeGB: api.WindowsBootstrapProfile.OSDiskSizeGB,
+			StaticIP:     api.WindowsBootstrapProfile.StaticIP,
+			Subnet:       api.WindowsBootstrapProfile.Subnet,
+		}
+	}
+	o.Registry = api.Registry
+	o.RegistryUser = api.RegistryUser
+	o.RegistryPass = api.RegistryPass
 }
 
 func convertCustomFilesToVlabs(a *MasterProfile, v *vlabs.MasterProfile) {

--- a/pkg/api/convertertoapi.go
+++ b/pkg/api/convertertoapi.go
@@ -152,42 +152,35 @@ func convertVLabsOrchestratorProfile(vp *vlabs.Properties, api *OrchestratorProf
 	api.OrchestratorType = vlabscs.OrchestratorType
 	switch api.OrchestratorType {
 	case DCOS:
-		if vlabscs.DcosConfig != nil {
-			api.DcosConfig = &DcosConfig{}
-			convertVLabsDcosConfig(vlabscs.DcosConfig, api.DcosConfig)
-		}
 		api.OrchestratorVersion = common.RationalizeReleaseAndVersion(
 			vlabscs.OrchestratorType,
 			vlabscs.OrchestratorRelease,
 			vlabscs.OrchestratorVersion,
 			false)
-	}
-}
-
-func convertVLabsDcosConfig(vlabs *vlabs.DcosConfig, api *DcosConfig) {
-	api.DcosBootstrapURL = vlabs.DcosBootstrapURL
-	api.DcosWindowsBootstrapURL = vlabs.DcosWindowsBootstrapURL
-
-	if len(vlabs.Registry) > 0 {
-		api.Registry = vlabs.Registry
-	}
-
-	if len(vlabs.RegistryUser) > 0 {
-		api.RegistryUser = vlabs.RegistryUser
-	}
-
-	if len(vlabs.RegistryPass) > 0 {
-		api.RegistryPass = vlabs.RegistryPass
-	}
-
-	if vlabs.BootstrapProfile != nil {
-		api.BootstrapProfile = &BootstrapProfile{
-			VMSize:       vlabs.BootstrapProfile.VMSize,
-			OSDiskSizeGB: vlabs.BootstrapProfile.OSDiskSizeGB,
-			OAuthEnabled: vlabs.BootstrapProfile.OAuthEnabled,
-			StaticIP:     vlabs.BootstrapProfile.StaticIP,
-			Subnet:       vlabs.BootstrapProfile.Subnet,
+		api.OAuthEnabled = vlabscs.OAuthEnabled
+		if vlabscs.LinuxBootstrapProfile != nil {
+			api.LinuxBootstrapProfile = &BootstrapProfile{
+				BootstrapURL: vlabscs.LinuxBootstrapProfile.BootstrapURL,
+				External:     vlabscs.LinuxBootstrapProfile.External,
+				VMSize:       vlabscs.LinuxBootstrapProfile.VMSize,
+				OSDiskSizeGB: vlabscs.LinuxBootstrapProfile.OSDiskSizeGB,
+				StaticIP:     vlabscs.LinuxBootstrapProfile.StaticIP,
+				Subnet:       vlabscs.LinuxBootstrapProfile.Subnet,
+			}
 		}
+		if vlabscs.WindowsBootstrapProfile != nil {
+			api.WindowsBootstrapProfile = &BootstrapProfile{
+				BootstrapURL: vlabscs.WindowsBootstrapProfile.BootstrapURL,
+				External:     vlabscs.WindowsBootstrapProfile.External,
+				VMSize:       vlabscs.WindowsBootstrapProfile.VMSize,
+				OSDiskSizeGB: vlabscs.WindowsBootstrapProfile.OSDiskSizeGB,
+				StaticIP:     vlabscs.WindowsBootstrapProfile.StaticIP,
+				Subnet:       vlabscs.WindowsBootstrapProfile.Subnet,
+			}
+		}
+		api.Registry = vlabscs.Registry
+		api.RegistryUser = vlabscs.RegistryUser
+		api.RegistryPass = vlabscs.RegistryPass
 	}
 }
 

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -130,9 +130,14 @@ const (
 
 // OrchestratorProfile contains Orchestrator properties
 type OrchestratorProfile struct {
-	OrchestratorType    string      `json:"orchestratorType"`
-	OrchestratorVersion string      `json:"orchestratorVersion"`
-	DcosConfig          *DcosConfig `json:"dcosConfig,omitempty"`
+	OrchestratorType        string            `json:"orchestratorType"`
+	OrchestratorVersion     string            `json:"orchestratorVersion"`
+	OAuthEnabled            bool              `json:"oauthEnabled,omitempty"`
+	LinuxBootstrapProfile   *BootstrapProfile `json:"linuxBootstrapProfile,omitempty"`
+	WindowsBootstrapProfile *BootstrapProfile `json:"windowsBootstrapProfile,omitempty"`
+	Registry                string            `json:"registry,omitempty"`
+	RegistryUser            string            `json:"registryUser,omitempty"`
+	RegistryPass            string            `json:"registryPassword,omitempty"`
 }
 
 // OrchestratorVersionProfile contains information of a supported orchestrator version:
@@ -159,21 +164,12 @@ type CustomFile struct {
 
 // BootstrapProfile represents the definition of the DCOS bootstrap node used to deploy the cluster
 type BootstrapProfile struct {
+	BootstrapURL string `json:"bootstrapURL,omitempty"`
+	External     bool   `json:"external,omitempty"`
 	VMSize       string `json:"vmSize,omitempty"`
 	OSDiskSizeGB int    `json:"osDiskSizeGB,omitempty"`
-	OAuthEnabled bool   `json:"oauthEnabled,omitempty"`
 	StaticIP     string `json:"staticIP,omitempty"`
 	Subnet       string `json:"subnet,omitempty"`
-}
-
-// DcosConfig Configuration for DC/OS
-type DcosConfig struct {
-	DcosBootstrapURL        string            `json:"dcosBootstrapURL,omitempty"`
-	DcosWindowsBootstrapURL string            `json:"dcosWindowsBootstrapURL,omitempty"`
-	Registry                string            `json:"registry,omitempty"`
-	RegistryUser            string            `json:"registryUser,omitempty"`
-	RegistryPass            string            `json:"registryPassword,omitempty"`
-	BootstrapProfile        *BootstrapProfile `json:"bootstrapProfile,omitempty"`
 }
 
 // MasterProfile represents the definition of the master cluster

--- a/pkg/api/vlabs/types.go
+++ b/pkg/api/vlabs/types.go
@@ -128,10 +128,15 @@ const (
 
 // OrchestratorProfile contains Orchestrator properties
 type OrchestratorProfile struct {
-	OrchestratorType    string      `json:"orchestratorType" validate:"required"`
-	OrchestratorRelease string      `json:"orchestratorRelease,omitempty"`
-	OrchestratorVersion string      `json:"orchestratorVersion,omitempty"`
-	DcosConfig          *DcosConfig `json:"dcosConfig,omitempty"`
+	OrchestratorType        string            `json:"orchestratorType" validate:"required"`
+	OrchestratorRelease     string            `json:"orchestratorRelease,omitempty"`
+	OrchestratorVersion     string            `json:"orchestratorVersion,omitempty"`
+	OAuthEnabled            bool              `json:"oauthEnabled,omitempty"`
+	LinuxBootstrapProfile   *BootstrapProfile `json:"linuxBootstrapProfile,omitempty"`
+	WindowsBootstrapProfile *BootstrapProfile `json:"windowsBootstrapProfile,omitempty"`
+	Registry                string            `json:"registry,omitempty"`
+	RegistryUser            string            `json:"registryUser,omitempty"`
+	RegistryPass            string            `json:"registryPassword,omitempty"`
 }
 
 // UnmarshalJSON unmarshal json using the default behavior
@@ -169,21 +174,12 @@ type CustomFile struct {
 
 // BootstrapProfile represents the definition of the DCOS bootstrap node used to deploy the cluster
 type BootstrapProfile struct {
+	BootstrapURL string `json:"bootstrapURL,omitempty"`
+	External     bool   `json:"external,omitempty"`
 	VMSize       string `json:"vmSize,omitempty"`
 	OSDiskSizeGB int    `json:"osDiskSizeGB,omitempty"`
-	OAuthEnabled bool   `json:"oauthEnabled,omitempty"`
 	StaticIP     string `json:"staticIP,omitempty"`
 	Subnet       string `json:"subnet,omitempty"`
-}
-
-// DcosConfig Configuration for DC/OS
-type DcosConfig struct {
-	DcosBootstrapURL        string            `json:"dcosBootstrapURL,omitempty"`
-	DcosWindowsBootstrapURL string            `json:"dcosWindowsBootstrapURL,omitempty"`
-	Registry                string            `json:"registry,omitempty"`
-	RegistryUser            string            `json:"registryUser,omitempty"`
-	RegistryPass            string            `json:"registryPassword,omitempty"`
-	BootstrapProfile        *BootstrapProfile `json:"bootstrapProfile,omitempty"`
 }
 
 // MasterProfile represents the definition of the master cluster

--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -77,12 +77,16 @@ func (a *Properties) validateOrchestratorProfile(isUpdate bool) error {
 			if version == "" {
 				return fmt.Errorf("the following OrchestratorProfile configuration is not supported: OrchestratorType: %s, OrchestratorRelease: %s, OrchestratorVersion: %s. Please check supported Release or Version for this build of dcos-engine", o.OrchestratorType, o.OrchestratorRelease, o.OrchestratorVersion)
 			}
-			if o.DcosConfig != nil && o.DcosConfig.BootstrapProfile != nil {
-				if len(o.DcosConfig.BootstrapProfile.StaticIP) > 0 {
-					if net.ParseIP(o.DcosConfig.BootstrapProfile.StaticIP) == nil {
-						return fmt.Errorf("DcosConfig.BootstrapProfile.StaticIP '%s' is an invalid IP address",
-							o.DcosConfig.BootstrapProfile.StaticIP)
-					}
+			if o.LinuxBootstrapProfile != nil && len(o.LinuxBootstrapProfile.StaticIP) > 0 {
+				if net.ParseIP(o.LinuxBootstrapProfile.StaticIP) == nil {
+					return fmt.Errorf("LinuxBootstrapProfile.StaticIP '%s' is an invalid IP address",
+						o.LinuxBootstrapProfile.StaticIP)
+				}
+			}
+			if o.WindowsBootstrapProfile != nil && len(o.WindowsBootstrapProfile.StaticIP) > 0 {
+				if net.ParseIP(o.WindowsBootstrapProfile.StaticIP) == nil {
+					return fmt.Errorf("WindowsBootstrapProfile.StaticIP '%s' is an invalid IP address",
+						o.WindowsBootstrapProfile.StaticIP)
 				}
 			}
 		default:
@@ -108,11 +112,6 @@ func (a *Properties) validateOrchestratorProfile(isUpdate bool) error {
 			}
 		}
 	}
-
-	if o.OrchestratorType != DCOS && o.DcosConfig != nil && (*o.DcosConfig != DcosConfig{}) {
-		return fmt.Errorf("DcosConfig can be specified only when OrchestratorType is DCOS")
-	}
-
 	return nil
 }
 

--- a/pkg/operations/dcosupgrade/upgrader.go
+++ b/pkg/operations/dcosupgrade/upgrader.go
@@ -69,9 +69,8 @@ bash ./dcos_node_upgrade.sh
 `
 
 func (uc *UpgradeCluster) runUpgrade() error {
-	if uc.ClusterTopology.DataModel.Properties.OrchestratorProfile.DcosConfig == nil ||
-		uc.ClusterTopology.DataModel.Properties.OrchestratorProfile.DcosConfig.BootstrapProfile == nil {
-		return fmt.Errorf("BootstrapProfile is not set")
+	if uc.ClusterTopology.DataModel.Properties.OrchestratorProfile.LinuxBootstrapProfile == nil {
+		return fmt.Errorf("LinuxBootstrapProfile is not set")
 	}
 	newVersion := uc.ClusterTopology.DataModel.Properties.OrchestratorProfile.OrchestratorVersion
 	masterDNS := acsengine.FormatAzureProdFQDN(uc.ClusterTopology.DataModel.Properties.MasterProfile.DNSPrefix, uc.ClusterTopology.DataModel.Location)
@@ -97,7 +96,7 @@ func (uc *UpgradeCluster) runUpgrade() error {
 	}
 
 	masterCount := uc.ClusterTopology.DataModel.Properties.MasterProfile.Count
-	bootstrapIP := uc.ClusterTopology.DataModel.Properties.OrchestratorProfile.DcosConfig.BootstrapProfile.StaticIP
+	bootstrapIP := uc.ClusterTopology.DataModel.Properties.OrchestratorProfile.LinuxBootstrapProfile.StaticIP
 	uc.Logger.Infof("masterDNS:%s masterCount:%d bootstrapIP:%s", masterDNS, masterCount, bootstrapIP)
 
 	if hasWindowsAgents {
@@ -119,7 +118,7 @@ func (uc *UpgradeCluster) runUpgrade() error {
 	// upgrade bootstrap node
 	bootstrapScript := strings.Replace(bootstrapUpgradeScript, "CURR_VERSION", uc.CurrentDcosVersion, -1)
 	bootstrapScript = strings.Replace(bootstrapScript, "NEW_VERSION", newVersion, -1)
-	bootstrapScript = strings.Replace(bootstrapScript, "BOOTSTRAP_URL", uc.ClusterTopology.DataModel.Properties.OrchestratorProfile.DcosConfig.DcosBootstrapURL, -1)
+	bootstrapScript = strings.Replace(bootstrapScript, "BOOTSTRAP_URL", uc.ClusterTopology.DataModel.Properties.OrchestratorProfile.LinuxBootstrapProfile.BootstrapURL, -1)
 
 	upgradeScriptURL, err := uc.upgradeBootstrapNode(masterDNS, bootstrapIP, bootstrapScript)
 	if err != nil {

--- a/test/cluster-defs/lnx/dcos-m1.lnx2-2.oauth.json
+++ b/test/cluster-defs/lnx/dcos-m1.lnx2-2.oauth.json
@@ -4,11 +4,7 @@
     "orchestratorProfile": {
       "orchestratorType": "DCOS",
       "orchestratorRelease": "",
-      "dcosConfig": {
-        "bootstrapProfile" : {
-          "oauthEnabled": true
-        }
-      }
+      "oauthEnabled": true
     },
     "masterProfile": {
       "count": 1,

--- a/test/cluster-defs/lnx/dcos-m3.lnx2-2.bstrap.vnet.json
+++ b/test/cluster-defs/lnx/dcos-m3.lnx2-2.bstrap.vnet.json
@@ -4,10 +4,8 @@
     "orchestratorProfile": {
       "orchestratorType": "DCOS",
       "orchestratorRelease": "",
-      "dcosConfig": {
-        "bootstrapProfile": {
-          "staticIP": "10.100.0.240"
-        }
+      "linuxBootstrapProfile": {
+        "staticIP": "10.100.0.240"
       }
     },
     "masterProfile": {


### PR DESCRIPTION
Changed structure of 'orchestratorProfile' in api model JSON to simplify and accomodate Linux and Windows bootstrap nodes.

Old structure:
{
  "orchestratorType": "val",
  "orchestratorRelease": "val",
  "dcosConfig": {
    "dcosBootstrapURL": "val",
    "dcosWindowsBootstrapURL": "val",
    "registry": "val",
    "registryUser": "val",
    "registryPassword": "val",
    "bootstrapProfile": {
      "vmSize": "val",
      "osDiskSizeGB": "val",
      "oauthEnabled": "val",
      "staticIP": "val",
      "subnet": "val"
    }
  }
}

New structure:
{
  "orchestratorType": "val",
  "orchestratorRelease": "val",
  "oauthEnabled": "val",
  "registry": "val",
  "registryUser": "val",
  "registryPassword": "val",
  "linuxBootstrapProfile": {
    "bootstrapURL": "val",
    "external": "val",
    "vmSize": "val",
    "osDiskSizeGB": "val",
    "staticIP": "val",
    "subnet": "val"
  },
  "windowsBootstrapProfile": {
    "bootstrapURL": "val"
  }
}

