### PR TITLE
Set public_ip custom attribute to true

### DIFF
--- a/pkg/acsengine/engine.go
+++ b/pkg/acsengine/engine.go
@@ -331,7 +331,7 @@ func getDCOSAgentCustomNodeLabels(profile *api.AgentPoolProfile) string {
 	}
 
 	if len(profile.Ports) > 0 {
-		attrstring += ";public_ip:yes"
+		attrstring += ";public_ip:true"
 	}
 
 	buf.WriteString(attrstring)
@@ -354,7 +354,7 @@ func getDCOSWindowsAgentCustomAttributes(profile *api.AgentPoolProfile) string {
 		attrstring = fmt.Sprintf("os:windows")
 	}
 	if len(profile.Ports) > 0 {
-		attrstring += ";public_ip:yes"
+		attrstring += ";public_ip:true"
 	}
 	buf.WriteString(attrstring)
 	if len(profile.CustomNodeLabels) > 0 {


### PR DESCRIPTION
The DC/OS web interface expects the value for the custom attribute `public_ip` to be `true` instead of `yes` in order to properly render it into the GUI as a public agent.

[This](https://github.com/dcos/dcos-ui/blob/541630cfa0223b8564244f26a5e3baaa6e3c0959/src/js/structs/Node.js#L98-L102) is the current master `dcos-ui` code doing this check.
