### PR TITLE
Add error checking for Windows pre-provision script

### DIFF
--- a/pkg/acsengine/engine.go
+++ b/pkg/acsengine/engine.go
@@ -238,7 +238,7 @@ func makeWindowsExtensionScriptCommands(extension *api.Extension, extensionProfi
 	scriptURL := getExtensionURL(extensionProfile.RootURL, extensionProfile.Name, extensionProfile.Version, extensionProfile.Script, extensionProfile.URLQuery)
 	scriptFileDir := fmt.Sprintf("$env:SystemDrive:/AzureData/extensions/%s", extensionProfile.Name)
 	scriptFilePath := fmt.Sprintf("%s/%s", scriptFileDir, extensionProfile.Script)
-	return fmt.Sprintf("New-Item -ItemType Directory -Force -Path \"%s\" ; Invoke-WebRequest -Uri \"%s\" -OutFile \"%s\" ; powershell \"%s %s\"\n", scriptFileDir, scriptURL, scriptFilePath, scriptFilePath, "$preprovisionExtensionParams")
+	return fmt.Sprintf("New-Item -ItemType Directory -Force -Path \"%s\" ; Invoke-WebRequest -Uri \"%s\" -OutFile \"%s\" ; powershell \"%s %s\" ; if($LASTEXITCODE) { Write-Output \"Failed to execute: %s\" ; exit 1 }\n", scriptFileDir, scriptURL, scriptFilePath, scriptFilePath, "$preprovisionExtensionParams", scriptFilePath)
 }
 
 func getDCOSWindowsAgentPreprovisionParameters(cs *api.ContainerService, profile *api.AgentPoolProfile) string {


### PR DESCRIPTION
This commits adds error checking for the PowerShell script executed via the pre-provision extension.