### PR TITLE
Create symlinks for chown and chmod

### DIFF
--- a/parts/dcos/dcos1.11.0.customdata.t
+++ b/parts/dcos/dcos1.11.0.customdata.t
@@ -29,6 +29,8 @@ runcmd: PREPROVISION_EXTENSION
 - ln -s /bin/systemctl /usr/bin/systemctl
 - ln -s /bin/mount /usr/bin/mount
 - ln -s /bin/bash /usr/bin/bash
+- ln -s /bin/chmod /usr/bin/chmod
+- ln -s /bin/chown /usr/bin/chown
 - ln -s /usr/sbin/useradd /usr/bin/useradd
 - systemctl disable --now resolvconf.service
 - systemctl mask --now lxc-net.service

--- a/parts/dcos/dcos1.11.2.customdata.t
+++ b/parts/dcos/dcos1.11.2.customdata.t
@@ -29,6 +29,8 @@ runcmd: PREPROVISION_EXTENSION
 - ln -s /bin/systemctl /usr/bin/systemctl
 - ln -s /bin/mount /usr/bin/mount
 - ln -s /bin/bash /usr/bin/bash
+- ln -s /bin/chmod /usr/bin/chmod
+- ln -s /bin/chown /usr/bin/chown
 - ln -s /usr/sbin/useradd /usr/bin/useradd
 - systemctl disable --now resolvconf.service
 - systemctl mask --now lxc-net.service


### PR DESCRIPTION
Since commit https://github.com/dcos/dcos/commit/c140fc7702be9edcbff420e7d29ae9e4237d5c2b, the `dcos-telegraf` service has `ExecStartPre=` definitions expecting `chmod` and `chown` to be present in `/usr/bin/`.