### PR TITLE
Fix dcos-diagnostics.service restart

### DIFF
--- a/test/ci/preprovision/extensions/postinstall-agent-windows/v1/postinstall-agent-windows.ps1
+++ b/test/ci/preprovision/extensions/postinstall-agent-windows/v1/postinstall-agent-windows.ps1
@@ -24,7 +24,7 @@ $ServiceList = "C:\opt\mesosphere\bin\servicelist.txt"
 $Content = Get-Content $ServiceList | Where-Object {$_ -notmatch 'dcos-metrics-agent.service'}
 Set-Content -Path $ServiceList -Value $Content
 
-& C:\opt\mesosphere\bin\systemctl.exe stop dcos-diagnostics.service
+& C:\opt\mesosphere\bin\systemctl.exe restart dcos-diagnostics.service
 if($LASTEXITCODE) {
     Throw "Failed to restart dcos-diagnostics.service"
 }


### PR DESCRIPTION
The `dcos-diagnostics.service` systemd service should be restarted at this point
