### PR TITLE
 Fix install of openssh to allow other than standard images

### DIFF
--- a/parts/dcos/bootstrapWindowsProvision.ps1
+++ b/parts/dcos/bootstrapWindowsProvision.ps1
@@ -95,12 +95,15 @@ function Install7zip
     Remove-Item C:\AzureData\7z\7z1801-x64.msi
 }
 
-function InstallOpehSSH()
+function InstallOpenSSH()
 {
-    Write-Log "Installing OpehSSH"
-    $list = (Get-WindowsCapability -Online | ? Name -like 'OpenSSH.Server*')
-    Add-WindowsCapability -Online -Name $list.Name
-    Install-Module -Force OpenSSHUtils
+    Write-Log "Installing OpenSSH"
+    $rslt = ( get-service | where { $.name -like "sshd" } )
+    if ( $rslt.count -eq 0) {
+        $list = (Get-WindowsCapability -Online | ? Name -like 'OpenSSH.Server*')
+        Add-WindowsCapability -Online -Name $list.Name
+        Install-Module -Force OpenSSHUtils
+    }
     Start-Service sshd
 
     Write-Log "Creating authorized key"
@@ -142,7 +145,7 @@ try {
     $systempart = (Get-Partition | where { $_.driveletter -eq "C" })
     $systempart | Resize-Partition -size $newSize
 
-    InstallOpehSSH
+    InstallOpenSSH
 
     Install7zip
 

--- a/parts/dcos/bootstrapWindowsProvision.ps1
+++ b/parts/dcos/bootstrapWindowsProvision.ps1
@@ -98,42 +98,47 @@ function Install7zip
 function InstallOpenSSH()
 {
     Write-Log "Installing OpenSSH"
-    $rslt = ( get-service | where { $.name -like "sshd" } )
-    if ( $rslt.count -eq 0) {
-        $list = (Get-WindowsCapability -Online | ? Name -like 'OpenSSH.Server*')
-        Add-WindowsCapability -Online -Name $list.Name
-        Install-Module -Force OpenSSHUtils
-    }
-    Start-Service sshd
-
-    Write-Log "Creating authorized key"
-    $path = "C:\AzureData\authorized_keys"
-    Set-Content -Path $path -Value "SSH_PUB_KEY" -Encoding Ascii
-
-    (Get-Content C:\ProgramData\ssh\sshd_config) -replace "AuthorizedKeysFile(\s+).ssh/authorized_keys", "AuthorizedKeysFile $path" | Set-Content C:\ProgramData\ssh\sshd_config
-    $acl = Get-Acl -Path $path
-    $acl.SetAccessRuleProtection($True, $True)
-    $acl | Set-Acl -Path $path
-
-    $acl = Get-Acl -Path $path
-    $rules = $acl.Access
-    $usersToRemove = @("Everyone","BUILTIN\Users","NT AUTHORITY\Authenticated Users")
-    foreach ($u in $usersToRemove) {
-        $targetrule = $rules | where IdentityReference -eq $u
-        if ($targetrule) {
-            $acl.RemoveAccessRule($targetrule)
+    try {
+        $rslt = ( get-service | where { $_.name -like "sshd" } )
+        if ( $rslt.count -eq 0) {
+            $list = (Get-WindowsCapability -Online | ? Name -like 'OpenSSH.Server*')
+            Add-WindowsCapability -Online -Name $list.Name
+            Install-Module -Force OpenSSHUtils
         }
-    }
-    $acl | Set-Acl -Path $path
+        Start-Service sshd
 
-    Restart-Service sshd
-
-    $sshStartCmd = "C:\AzureData\OpenSSHStart.ps1"
-    Set-Content -Path $sshStartCmd -Value "Start-Service sshd"
-
-    & schtasks.exe /CREATE /F /SC ONSTART /RU SYSTEM /RL HIGHEST /TN "SSH start" /TR "powershell.exe -ExecutionPolicy Bypass -File $sshStartCmd"
-    if ($LASTEXITCODE -ne 0) {
-        throw "Failed to add scheduled task $sshStartCmd"
+        Write-Log "Creating authorized key"
+        $path = "C:\AzureData\authorized_keys"
+        Set-Content -Path $path -Value "SSH_PUB_KEY" -Encoding Ascii
+    
+        (Get-Content C:\ProgramData\ssh\sshd_config) -replace "AuthorizedKeysFile(\s+).ssh/authorized_keys", "AuthorizedKeysFile $path" | Set-Content C:\ProgramData\ssh\sshd_config
+        $acl = Get-Acl -Path $path
+        $acl.SetAccessRuleProtection($True, $True)
+        $acl | Set-Acl -Path $path
+    
+        $acl = Get-Acl -Path $path
+        $rules = $acl.Access
+        $usersToRemove = @("Everyone","BUILTIN\Users","NT AUTHORITY\Authenticated Users")
+        foreach ($u in $usersToRemove) {
+            $targetrule = $rules | where IdentityReference -eq $u
+            if ($targetrule) {
+                $acl.RemoveAccessRule($targetrule)
+            }
+        }
+        $acl | Set-Acl -Path $path
+    
+        Restart-Service sshd
+    
+        $sshStartCmd = "C:\AzureData\OpenSSHStart.ps1"
+        Set-Content -Path $sshStartCmd -Value "Start-Service sshd"
+    
+        & schtasks.exe /CREATE /F /SC ONSTART /RU SYSTEM /RL HIGHEST /TN "SSH start" /TR "powershell.exe -ExecutionPolicy Bypass -File $sshStartCmd"
+        if ($LASTEXITCODE -ne 0) {
+            throw "Failed to add scheduled task $sshStartCmd"
+        }
+    } 
+    catch {
+       Write-Log "OpenSSH install failed: $_"
     }
 }
 

--- a/parts/dcos/dcosWindowsProvision.ps1
+++ b/parts/dcos/dcosWindowsProvision.ps1
@@ -67,12 +67,15 @@ function UpdateDocker()
     Start-Service Docker
 }
 
-function InstallOpehSSH()
+function InstallOpenSSH()
 {
-    Write-Log "Installing OpehSSH"
-    $list = (Get-WindowsCapability -Online | ? Name -like 'OpenSSH.Server*')
-    Add-WindowsCapability -Online -Name $list.Name
-    Install-Module -Force OpenSSHUtils
+    Write-Log "Installing OpenSSH"
+    $rslt = ( get-service | where { $.name -like "sshd" } )
+    if ( $rslt.count -eq 0) {
+        $list = (Get-WindowsCapability -Online | ? Name -like 'OpenSSH.Server*')
+        Add-WindowsCapability -Online -Name $list.Name
+        Install-Module -Force OpenSSHUtils
+    }
     Start-Service sshd
 
     Write-Log "Creating authorized key"
@@ -157,7 +160,7 @@ try {
 
     UpdateDocker
 
-    InstallOpehSSH
+    InstallOpenSSH
 
     # First up, download the runasxbox util
     RetryCurl "https://dcos-mirror.azureedge.net/winbootstrap/RunAsXbox.exe" "c:\AzureData\runasxbox.exe"

--- a/parts/dcos/dcosWindowsProvision.ps1
+++ b/parts/dcos/dcosWindowsProvision.ps1
@@ -70,7 +70,7 @@ function UpdateDocker()
 function InstallOpenSSH()
 {
     Write-Log "Installing OpenSSH"
-    $rslt = ( get-service | where { $.name -like "sshd" } )
+    $rslt = ( get-service | where { $_.name -like "sshd" } )
     if ( $rslt.count -eq 0) {
         $list = (Get-WindowsCapability -Online | ? Name -like 'OpenSSH.Server*')
         Add-WindowsCapability -Online -Name $list.Name

--- a/pkg/acsengine/template_generator.go
+++ b/pkg/acsengine/template_generator.go
@@ -177,7 +177,7 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 			return getDataDisks(profile)
 		},
 		"HasBootstrapPublicIP": func() bool {
-			return false
+			return true
 		},
 		"IsHostedBootstrap": func() bool {
 			return cs.Properties.OrchestratorProfile.LinuxBootstrapProfile.Hosted

--- a/pkg/acsengine/template_generator.go
+++ b/pkg/acsengine/template_generator.go
@@ -177,7 +177,7 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 			return getDataDisks(profile)
 		},
 		"HasBootstrapPublicIP": func() bool {
-			return true
+			return false
 		},
 		"IsHostedBootstrap": func() bool {
 			return cs.Properties.OrchestratorProfile.LinuxBootstrapProfile.Hosted


### PR DESCRIPTION

Fix install of openssh to allow other than standard images. Currently openssh install fails if the image isn't backed by get-windowscapability/add-windowscapability which fails the bootstrap nodes. Insider images for example all fail. This checks to see if the ssh is preprovisioned, and if not still allows the bootstrap node to continue deploying even if openssh has trouble.  
