### PR TITLE
Refactor pre and post provision extension download and execution.

### DIFF
--- a/pkg/acsengine/engine.go
+++ b/pkg/acsengine/engine.go
@@ -206,9 +206,9 @@ func makeExtensionScriptCommands(extension *api.Extension, extensionProfiles []*
 		scriptFilePath, scriptURL, scriptFilePath, scriptFilePath, extensionsParameterReference, extensionProfile.Name)
 }
 
-func makeWindowsExtensionScriptCommands(extension *api.Extension, extensionProfiles []*api.ExtensionProfile) string {
+func getWindowsExtensionScriptData(extension *api.Extension, extensionProfiles []*api.ExtensionProfile) (string, string, string) {
 	if extension == nil {
-		return ""
+		return "", "", ""
 	}
 	var extensionProfile *api.ExtensionProfile
 	for _, eP := range extensionProfiles {
@@ -225,7 +225,10 @@ func makeWindowsExtensionScriptCommands(extension *api.Extension, extensionProfi
 	scriptURL := getExtensionURL(extensionProfile.RootURL, extensionProfile.Name, extensionProfile.Version, extensionProfile.Script, extensionProfile.URLQuery)
 	scriptFileDir := fmt.Sprintf("$env:SystemDrive:/AzureData/extensions/%s", extensionProfile.Name)
 	scriptFilePath := fmt.Sprintf("%s/%s", scriptFileDir, extensionProfile.Script)
-	return fmt.Sprintf("New-Item -ItemType Directory -Force -Path \"%s\" ; Invoke-WebRequest -Uri \"%s\" -OutFile \"%s\" ; powershell \"%s %s\" ; if($LASTEXITCODE) { Write-Output \"Failed to execute: %s\" ; exit 1 }\n", scriptFileDir, scriptURL, scriptFilePath, scriptFilePath, "$preprovisionExtensionParams", scriptFilePath)
+	scriptURL = "\"" + scriptURL + "\""
+	scriptFileDir = "\"" + scriptFileDir + "\""
+	scriptFilePath = "\"" + scriptFilePath + "\""
+	return scriptURL, scriptFileDir, scriptFilePath
 }
 
 func getDCOSWindowsAgentPreprovisionParameters(cs *api.ContainerService, profile *api.AgentPoolProfile) string {

--- a/pkg/acsengine/template_generator.go
+++ b/pkg/acsengine/template_generator.go
@@ -199,7 +199,6 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 					"PROVISION_SOURCE_STR": getDCOSProvisionScript(dcosProvisionSource),
 					"PROVISION_STR":        getDCOSProvisionScript(dcosBootstrapProvision),
 				})
-
 			return fmt.Sprintf("\"customData\": \"[base64(concat('#cloud-config\\n\\n', '%s'))]\",", str)
 		},
 		"GetDCOSBootstrapWindowsCustomData": func() string {
@@ -262,8 +261,8 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 			return fmt.Sprintf("\"customData\": \"[base64(concat('#cloud-config\\n\\n', '%s'))]\",", str)
 		},
 		"GetDCOSWindowsAgentCustomData": func(profile *api.AgentPoolProfile) string {
-			preprovisionExtension := makeWindowsExtensionScriptCommands(profile.PreprovisionExtension, cs.Properties.ExtensionProfiles)
-			postprovisionExtension := makeWindowsExtensionScriptCommands(profile.PostprovisionExtension, cs.Properties.ExtensionProfiles)
+			preprovisionExtensionURL, preprovisionExtensionDir, preprovisionExtensionPath := getWindowsExtensionScriptData(profile.PreprovisionExtension, cs.Properties.ExtensionProfiles)
+			postprovisionExtensionURL, postprovisionExtensionDir, postprovisionExtensionPath := getWindowsExtensionScriptData(profile.PostprovisionExtension, cs.Properties.ExtensionProfiles)
 			b, err := Asset(dcosWindowsProvision)
 			if err != nil {
 				// this should never happen and this is a bug
@@ -277,8 +276,12 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 			}
 			// translate the parameters
 			csStr := string(b)
-			csStr = strings.Replace(csStr, "PREPROVISION_EXTENSION", preprovisionExtension, -1)
-			csStr = strings.Replace(csStr, "POSTPROVISION_EXTENSION", postprovisionExtension, -1)
+			csStr = strings.Replace(csStr, "PREPROVISION_EXTENSION_URL", preprovisionExtensionURL, -1)
+			csStr = strings.Replace(csStr, "PREPROVISION_EXTENSION_DIR", preprovisionExtensionDir, -1)
+			csStr = strings.Replace(csStr, "PREPROVISION_EXTENSION_PATH", preprovisionExtensionPath, -1)
+			csStr = strings.Replace(csStr, "POSTPROVISION_EXTENSION_URL", postprovisionExtensionURL, -1)
+			csStr = strings.Replace(csStr, "POSTPROVISION_EXTENSION_DIR", postprovisionExtensionDir, -1)
+			csStr = strings.Replace(csStr, "POSTPROVISION_EXTENSION_PATH", postprovisionExtensionPath, -1)
 			csStr = strings.Replace(csStr, "ROLENAME", agentRoleName, -1)
 			csStr = strings.Replace(csStr, "SSH_PUB_KEY", cs.Properties.LinuxProfile.SSH.PublicKeys[0].KeyData, -1)
 			csStr = strings.Replace(csStr, "ADMIN_PASSWORD", cs.Properties.WindowsProfile.AdminPassword, -1)


### PR DESCRIPTION
- Refactor the download and execution process to **add retries** when fetching the **preprovision** and **postinstall** scripts for windows agents.

