### PR TITLE
Allow extra configs to be added to BootstrapProfile

### DIFF
--- a/pkg/api/converterfromapi.go
+++ b/pkg/api/converterfromapi.go
@@ -182,6 +182,7 @@ func convertOrchestratorProfileToVLabs(api *OrchestratorProfile, o *vlabs.Orches
 			HasPublicIP:   api.LinuxBootstrapProfile.HasPublicIP,
 			Subnet:        api.LinuxBootstrapProfile.Subnet,
 			EnableIPv6:    api.LinuxBootstrapProfile.EnableIPv6,
+			ExtraConfigs:  api.LinuxBootstrapProfile.ExtraConfigs,
 		}
 	}
 	if api.WindowsBootstrapProfile != nil {
@@ -195,6 +196,7 @@ func convertOrchestratorProfileToVLabs(api *OrchestratorProfile, o *vlabs.Orches
 			HasPublicIP:   api.WindowsBootstrapProfile.HasPublicIP,
 			Subnet:        api.WindowsBootstrapProfile.Subnet,
 			EnableIPv6:    api.WindowsBootstrapProfile.EnableIPv6,
+			ExtraConfigs:  api.WindowsBootstrapProfile.ExtraConfigs,
 		}
 	}
 	o.Registry = api.Registry

--- a/pkg/api/convertertoapi.go
+++ b/pkg/api/convertertoapi.go
@@ -170,6 +170,7 @@ func convertVLabsOrchestratorProfile(vp *vlabs.Properties, api *OrchestratorProf
 				HasPublicIP:   vlabscs.LinuxBootstrapProfile.HasPublicIP,
 				Subnet:        vlabscs.LinuxBootstrapProfile.Subnet,
 				EnableIPv6:    vlabscs.LinuxBootstrapProfile.EnableIPv6,
+				ExtraConfigs:  vlabscs.LinuxBootstrapProfile.ExtraConfigs,
 			}
 		}
 		if vlabscs.WindowsBootstrapProfile != nil {
@@ -183,6 +184,7 @@ func convertVLabsOrchestratorProfile(vp *vlabs.Properties, api *OrchestratorProf
 				HasPublicIP:   vlabscs.WindowsBootstrapProfile.HasPublicIP,
 				Subnet:        vlabscs.WindowsBootstrapProfile.Subnet,
 				EnableIPv6:    vlabscs.WindowsBootstrapProfile.EnableIPv6,
+				ExtraConfigs:  vlabscs.WindowsBootstrapProfile.ExtraConfigs,
 			}
 		}
 		api.Registry = vlabscs.Registry

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -165,15 +165,16 @@ type CustomFile struct {
 
 // BootstrapProfile represents the definition of the DCOS bootstrap node used to deploy the cluster
 type BootstrapProfile struct {
-	BootstrapURL  string `json:"bootstrapURL,omitempty"`
-	DockerVersion string `json:"dockerVersion,omitempty"`
-	Hosted        bool   `json:"hosted,omitempty"`
-	VMSize        string `json:"vmSize,omitempty"`
-	OSDiskSizeGB  int    `json:"osDiskSizeGB,omitempty"`
-	StaticIP      string `json:"staticIP,omitempty"`
-	HasPublicIP   bool   `json:"hasPublicIP,omitempty"`
-	Subnet        string `json:"subnet,omitempty"`
-	EnableIPv6    bool   `json:"enableIPv6,omitempty"`
+	BootstrapURL  string                 `json:"bootstrapURL,omitempty"`
+	DockerVersion string                 `json:"dockerVersion,omitempty"`
+	Hosted        bool                   `json:"hosted,omitempty"`
+	VMSize        string                 `json:"vmSize,omitempty"`
+	OSDiskSizeGB  int                    `json:"osDiskSizeGB,omitempty"`
+	StaticIP      string                 `json:"staticIP,omitempty"`
+	HasPublicIP   bool                   `json:"hasPublicIP,omitempty"`
+	Subnet        string                 `json:"subnet,omitempty"`
+	EnableIPv6    bool                   `json:"enableIPv6,omitempty"`
+	ExtraConfigs  map[string]interface{} `json:"extraConfigs,omitempty"`
 }
 
 // MasterProfile represents the definition of the master cluster

--- a/pkg/api/vlabs/types.go
+++ b/pkg/api/vlabs/types.go
@@ -175,15 +175,16 @@ type CustomFile struct {
 
 // BootstrapProfile represents the definition of the DCOS bootstrap node used to deploy the cluster
 type BootstrapProfile struct {
-	BootstrapURL  string `json:"bootstrapURL,omitempty"`
-	DockerVersion string `json:"dockerVersion,omitempty"`
-	Hosted        bool   `json:"hosted,omitempty"`
-	VMSize        string `json:"vmSize,omitempty"`
-	OSDiskSizeGB  int    `json:"osDiskSizeGB,omitempty"`
-	StaticIP      string `json:"staticIP,omitempty"`
-	HasPublicIP   bool   `json:"hasPublicIP,omitempty"`
-	Subnet        string `json:"subnet,omitempty"`
-	EnableIPv6    bool   `json:"enableIPv6,omitempty"`
+	BootstrapURL  string                 `json:"bootstrapURL,omitempty"`
+	DockerVersion string                 `json:"dockerVersion,omitempty"`
+	Hosted        bool                   `json:"hosted,omitempty"`
+	VMSize        string                 `json:"vmSize,omitempty"`
+	OSDiskSizeGB  int                    `json:"osDiskSizeGB,omitempty"`
+	StaticIP      string                 `json:"staticIP,omitempty"`
+	HasPublicIP   bool                   `json:"hasPublicIP,omitempty"`
+	Subnet        string                 `json:"subnet,omitempty"`
+	EnableIPv6    bool                   `json:"enableIPv6,omitempty"`
+	ExtraConfigs  map[string]interface{} `json:"extraConfigs,omitempty"`
 }
 
 // MasterProfile represents the definition of the master cluster


### PR DESCRIPTION
**What this PR does / why we need it**:

Allow Bootstrap extra configs to be passed in json file
Entries in ExtraConfigs field from BootstrapProfile are added to the config.yaml to the bootstrap node