### PR TITLE
Bump Windows Docker version to latest EE

### DIFF
--- a/test/cluster-defs/hyb/dcos-m1.lnx2-2.win2-2.json
+++ b/test/cluster-defs/hyb/dcos-m1.lnx2-2.win2-2.json
@@ -5,6 +5,7 @@
       "orchestratorType": "DCOS",
       "orchestratorRelease": "",
       "windowsBootstrapProfile": {
+        "dockerVersion": "18.03.1-ee-3",
         "bootstrapURL": "https://dcosci.blob.core.windows.net/dcos-windows/stable/dcos_generate_config.windows.tar.xz",
         "vmSize": "Standard_D8s_v3"
       }

--- a/test/cluster-defs/hyb/dcos-m3.lnx1-2.win1-2.json
+++ b/test/cluster-defs/hyb/dcos-m3.lnx1-2.win1-2.json
@@ -5,6 +5,7 @@
       "orchestratorType": "DCOS",
       "orchestratorRelease": "",
       "windowsBootstrapProfile": {
+        "dockerVersion": "18.03.1-ee-3",
         "bootstrapURL": "https://dcosci.blob.core.windows.net/dcos-windows/stable/dcos_generate_config.windows.tar.xz",
         "vmSize": "Standard_D8s_v3"
       }

--- a/test/cluster-defs/hyb/dcos-m3.lnx1-2.win1-2.preprov.json
+++ b/test/cluster-defs/hyb/dcos-m3.lnx1-2.win1-2.preprov.json
@@ -5,6 +5,7 @@
       "orchestratorType": "DCOS",
       "orchestratorRelease": "",
       "windowsBootstrapProfile": {
+        "dockerVersion": "18.03.1-ee-3",
         "bootstrapURL": "https://dcosci.blob.core.windows.net/dcos-windows/stable/dcos_generate_config.windows.tar.xz",
         "vmSize": "Standard_D8s_v3"
       }

--- a/test/cluster-defs/upgrade/dcos1.11.2-m3.lnx1-2.win1-2.json
+++ b/test/cluster-defs/upgrade/dcos1.11.2-m3.lnx1-2.win1-2.json
@@ -5,6 +5,7 @@
       "orchestratorType": "DCOS",
       "orchestratorVersion": "1.11.2",
       "windowsBootstrapProfile": {
+        "dockerVersion": "18.03.1-ee-3",
         "bootstrapURL": "https://dcosci.blob.core.windows.net/dcos-windows/stable/dcos_generate_config.windows.tar.xz",
         "vmSize": "Standard_D8s_v3"
       }

--- a/test/cluster-defs/upgrade/dcos1.11.4-m1.lnx1-2.win1-2.json
+++ b/test/cluster-defs/upgrade/dcos1.11.4-m1.lnx1-2.win1-2.json
@@ -5,6 +5,7 @@
       "orchestratorType": "DCOS",
       "orchestratorVersion": "1.11.4",
       "windowsBootstrapProfile": {
+        "dockerVersion": "18.03.1-ee-3",
         "bootstrapURL": "https://dcosci.blob.core.windows.net/dcos-windows/stable/dcos_generate_config.windows.tar.xz",
         "vmSize": "Standard_D8s_v3"
       }

--- a/test/cluster-defs/win/dcos-m1.win2-2.json
+++ b/test/cluster-defs/win/dcos-m1.win2-2.json
@@ -5,6 +5,7 @@
       "orchestratorType": "DCOS",
       "orchestratorRelease": "",
       "windowsBootstrapProfile": {
+        "dockerVersion": "18.03.1-ee-3",
         "bootstrapURL": "https://dcosci.blob.core.windows.net/dcos-windows/stable/dcos_generate_config.windows.tar.xz",
         "vmSize": "Standard_D8s_v3"
       }


### PR DESCRIPTION
Use latest `18.03.1-ee-3` Windows Docker version for the testing DC/OS Windows agents.