### PR TITLE
Add retry to dcos-metrics Stop-Service

### DIFF
--- a/test/ci/preprovision/extensions/postinstall-agent-windows/v1/postinstall-agent-windows.ps1
+++ b/test/ci/preprovision/extensions/postinstall-agent-windows/v1/postinstall-agent-windows.ps1
@@ -89,7 +89,7 @@ Start-Service $serviceName
 #
 # Disable dcos-metrics agent
 #
-Stop-Service -Force "dcos-metrics-agent.service"
+Start-ExecuteWithRetry { Stop-Service -Force "dcos-metrics-agent.service" }
 sc.exe delete "dcos-metrics-agent.service"
 if($LASTEXITCODE) {
     Throw "Failed to delete dcos-metrics-agent.service"


### PR DESCRIPTION
The dcos-metrics agent is constantly flipping between stopped / running
when Mesos auth is enabled.

Sometimes, the Stop-Service will fail if the service is stopped
into a flipping state even though the service is successfully stopped.
Adding a retry will solve this.