### PR TITLE
Increase allowed timeout

### DIFF
--- a/parts/dcos/dcosWindowsProvision.ps1
+++ b/parts/dcos/dcosWindowsProvision.ps1
@@ -449,7 +449,7 @@ function Set-MesosFlags {
         Write-Log "Mesos flags are already set"
         return
     }
-    $timeout = 5400.0 # 1 hour and 30 minutes timeout
+    $timeout = 7200.0 # 2 hours
     $startTime = Get-Date
     while(((Get-Date) - $startTime).TotalSeconds -lt $timeout) {
         try {


### PR DESCRIPTION
Turns out that worse case scenario is not covered by this maximum
allowed timeout.

The 7200 seconds value was present in the old deployments without
Pkgpanda (https://github.com/dcos/dcos-windows/blob/9114dba3e18b54ffd8c8cdd753e07dbbfb31a5ad/scripts/agent-setup.ps1#L190) and it was found more reliable.
