### PR TITLE
Remove 7z.exe full path.

### DIFF
--- a/pkg/operations/dcosupgrade/upgrader-win.go
+++ b/pkg/operations/dcosupgrade/upgrader-win.go
@@ -73,7 +73,7 @@ try {
 	\$path = Join-Path \$upgradeDir "dcos_generate_config.windows.tar.xz"
 	RetryCurl \$BootstrapURL \$path
 
-	& cmd /c "c:\AzureData\7z\7z.exe e .\dcos_generate_config.windows.tar.xz -so | c:\AzureData\7z\7z.exe x -si -ttar"
+	& cmd /c "7z.exe e .\dcos_generate_config.windows.tar.xz -so | 7z.exe x -si -ttar"
 	if (\$LASTEXITCODE -ne 0) {
 		throw "Failed to untar dcos_generate_config.windows.tar.xz"
 	}


### PR DESCRIPTION
- This PR fixes the usage of 7z.exe, since it's no longer installed in `C:\AzureData\7z`, but in `C:\Program Files\7-Zip`, and the binary is now in `$PATH`;